### PR TITLE
GOODPUT: Resolving compiler warnings and handle some segfault conditions

### DIFF
--- a/goodput/common/include/libcli.h
+++ b/goodput/common/include/libcli.h
@@ -53,8 +53,11 @@ extern "C" {
 
 /* Send string to one/all of the many output streams supported by cli_env */
 #define LOGMSG(env, format, ...) \
-	snprintf(env->output, sizeof(env->output), format, ##__VA_ARGS__); \
-	logMsg(env);
+	do { \
+		snprintf(env->output, sizeof(env->output), format, ##__VA_ARGS__); \
+		logMsg(env); \
+	} while (0)
+		 
 
 struct cli_cmd;
 

--- a/goodput/src/goodput_cli.c
+++ b/goodput/src/goodput_cli.c
@@ -1865,7 +1865,7 @@ static void display_msg_status(struct cli_env *env)
 			wkr[i].con_skt_valid, wkr[i].msg_size,
 			wkr[i].sock_num, (NULL != wkr[i].sock_tx_buf),
 			(NULL != wkr[i].sock_rx_buf)
-		)
+		);
 	}
 }
 

--- a/goodput/src/worker.c
+++ b/goodput/src/worker.c
@@ -1443,9 +1443,9 @@ bool dma_alloc_ibwin(struct worker *info)
 		info->ib_ptr = NULL;
 
 	if (NULL == info->ib_ptr) {
-		rio_ibwin_free(info->mp_h, &info->ib_handle);
 		ERR("FAILED: riomp_dma_map_memory errno %d:%s\n",
 					errno, strerror(errno));
+		rio_ibwin_free(info->mp_h, &info->ib_handle);
 		return false;
 	}
 	if (info->ib_ptr == NULL) {

--- a/goodput/src/worker.c
+++ b/goodput/src/worker.c
@@ -435,12 +435,22 @@ int direct_io_obwin_map(struct worker *info)
 	info->ob_valid = 1;
 
 	info->ob_ptr = mmap(NULL, info->ob_byte_cnt, PROT_READ | PROT_WRITE,
-		MAP_SHARED, info->mp_h, info->mp_h);
+		MAP_SHARED, info->mp_h, info->ob_handle);
+
+	if (info->ob_ptr == MAP_FAILED)
+		info->ob_ptr = NULL;
+
+	if (info->ob_ptr == NULL) {
+		ERR("FAILED: mmap %d:%s\n",errno,strerror(errno));
+		rc = 1;
+		goto exit;
+	}
+
 	// rc = riomp_dma_map_memory(info->mp_h, info->ob_byte_cnt,
 	//			info->ob_handle, &info->ob_ptr);
-	if (rc)
-		ERR("FAILED: riomp_dma_map_memory rc %d:%s\n",
-					rc, strerror(errno));
+	//if (rc)
+	//	ERR("FAILED: riomp_dma_map_memory rc %d:%s\n",
+	//		rc, strerror(errno));
 exit:
 	return rc;
 }
@@ -622,9 +632,13 @@ int alloc_dma_tx_buffer(struct worker *info)
 			info->mp_h, info->rdma_kbuff);
 		// rc = riomp_dma_map_memory(info->mp_h, info->rdma_buff_size,
 		//			info->rdma_kbuff, &info->rdma_ptr);
+		if (info->rdma_ptr == MAP_FAILED)
+			info->rdma_ptr = NULL;
+
 		if (NULL == info->rdma_ptr) {
 			ERR("FAILED: mmap rc %d:%s\n",
 						rc, strerror(errno));
+			rc = 1;
 			goto exit;
 		}
 	} else {
@@ -787,7 +801,7 @@ void dma_goodput(struct worker *info)
 	while (!info->stop_req) {
 		uint64_t cnt;
 
-		if (dma_tx_lat == info->action) {
+		if (dma_tx_lat == info->action && info->wr) {
 			start_iter_stats(info);
 			*rx_flag = info->perf_iter_cnt + 1;
 		}
@@ -1425,6 +1439,9 @@ bool dma_alloc_ibwin(struct worker *info)
 				MAP_SHARED, info->mp_h, info->ib_handle);
 	// rc = riomp_dma_map_memory(info->mp_h, info->ib_byte_cnt,
 	//				info->ib_handle, &info->ib_ptr);
+	if (info->ib_ptr == MAP_FAILED)
+		info->ib_ptr = NULL;
+
 	if (NULL == info->ib_ptr) {
 		rio_ibwin_free(info->mp_h, &info->ib_handle);
 		ERR("FAILED: riomp_dma_map_memory rc %d:%s\n",

--- a/goodput/src/worker.c
+++ b/goodput/src/worker.c
@@ -636,8 +636,8 @@ int alloc_dma_tx_buffer(struct worker *info)
 			info->rdma_ptr = NULL;
 
 		if (NULL == info->rdma_ptr) {
-			ERR("FAILED: mmap rc %d:%s\n",
-						rc, strerror(errno));
+			ERR("FAILED: mmap errno %d:%s\n",
+						errno, strerror(errno));
 			rc = 1;
 			goto exit;
 		}
@@ -1444,8 +1444,8 @@ bool dma_alloc_ibwin(struct worker *info)
 
 	if (NULL == info->ib_ptr) {
 		rio_ibwin_free(info->mp_h, &info->ib_handle);
-		ERR("FAILED: riomp_dma_map_memory rc %d:%s\n",
-					rc, strerror(errno));
+		ERR("FAILED: riomp_dma_map_memory errno %d:%s\n",
+					errno, strerror(errno));
 		return false;
 	}
 	if (info->ib_ptr == NULL) {


### PR DESCRIPTION
Fix for GCC 8 build warning related to multi-statement macro
Fix for segfault conditions in goodput
  mmap checked against MAP_FAILED instead of NULL
  only set rx_flag in condition where it's checked valid