### PR TITLE
GOODPUT: CLI initialization error reporting

### DIFF
--- a/goodput/common/include/liblog.h
+++ b/goodput/common/include/liblog.h
@@ -115,7 +115,7 @@ void rdma_log_dump();
 
 void rdma_log_close();
 
-void liblog_bind_cli_cmds();
+int liblog_bind_cli_cmds();
 
 extern unsigned g_level;
 extern unsigned g_disp_level;

--- a/goodput/common/libcli/src/cli_base_init.c
+++ b/goodput/common/libcli/src/cli_base_init.c
@@ -48,15 +48,17 @@ void default_cons_cleanup(struct cli_env *env)
 
 int cli_init_base(void (*console_cleanup)(struct cli_env *env))
 {
-	init_cmd_db();
-	bind_cli_cmd_line_cmds();
+	int rc;
+
+	rc = init_cmd_db();
+	rc |= bind_cli_cmd_line_cmds();
 
 	if (NULL != console_cleanup) {
 		cons_cleanup = console_cleanup;
 	} else {
 		cons_cleanup = default_cons_cleanup;
 	}
-	return 0;
+	return rc;
 }
 
 #ifdef __cplusplus

--- a/goodput/common/libcli/src/cli_cmd_db.c
+++ b/goodput/common/libcli/src/cli_cmd_db.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include "libcli.h"
 
-#define MAX_CMDS 120
+#define MAX_CMDS 100
 #define MIN(a, b) ((a < b)?a:b)
 
 #ifdef __cplusplus
@@ -183,9 +183,7 @@ int init_cmd_db(void)
 	struct cli_cmd *help_ptr = &CLIHelp;
 
 	num_valid_cmds = 0;
-	add_commands_to_cmd_db(1, &help_ptr);
-
-	return 0;
+	return add_commands_to_cmd_db(1, &help_ptr);
 }
 
 #ifdef __cplusplus

--- a/goodput/common/libcli/src/cli_cmd_line.c
+++ b/goodput/common/libcli/src/cli_cmd_line.c
@@ -676,9 +676,9 @@ int bind_cli_cmd_line_cmds(void)
 		snprintf(script_path, SCRIPT_PATH_LEN, "%s/scripts/", cwd);
 	}
 
-	add_commands_to_cmd_db(sizeof(cmd_line_cmds) / sizeof(struct cli_cmd *),
+	return add_commands_to_cmd_db(
+			sizeof(cmd_line_cmds) / sizeof(struct cli_cmd *),
 			cmd_line_cmds);
-	return 0;
 }
 
 #ifdef __cplusplus

--- a/goodput/common/liblog/src/liblog_cli.c
+++ b/goodput/common/liblog/src/liblog_cli.c
@@ -145,9 +145,10 @@ ATTR_NONE};
 
 struct cli_cmd *liblog_cmds[] = {&LogLevel, &DispLevel, &log_dump_cmd};
 
-void liblog_bind_cli_cmds(void)
+int liblog_bind_cli_cmds(void)
 {
-	add_commands_to_cmd_db(sizeof(liblog_cmds) / sizeof(liblog_cmds[0]),
+	return add_commands_to_cmd_db(
+			sizeof(liblog_cmds) / sizeof(liblog_cmds[0]),
 			liblog_cmds);
 }
 

--- a/goodput/inc/goodput_cli.h
+++ b/goodput/inc/goodput_cli.h
@@ -50,7 +50,7 @@ extern "C" {
  *
  */
 
-void bind_goodput_cmds(void);
+int bind_goodput_cmds(void);
 
 #ifdef __cplusplus
 }

--- a/goodput/src/goodput.c
+++ b/goodput/src/goodput.c
@@ -125,6 +125,7 @@ int main(int argc, char *argv[])
 
 	char* rc_script = NULL;
 	struct cli_env t_env;
+	int cli_rc;
 
 	signal(SIGINT, sig_handler);
 	signal(SIGHUP, sig_handler);
@@ -163,9 +164,17 @@ int main(int argc, char *argv[])
 	for (int i = 0; i < MAX_WORKERS; i++)
 		init_worker_info(&wkr[i], 1);
 
-	cli_init_base(goodput_thread_shutdown);
-	liblog_bind_cli_cmds();
-	bind_goodput_cmds();
+	cli_rc = cli_init_base(goodput_thread_shutdown);
+	cli_rc |= liblog_bind_cli_cmds();
+	cli_rc |= bind_goodput_cmds();
+	if (cli_rc) {
+		printf(	"\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+			"\n!!!                                          !!!"
+			"\n!!!  WARNING: CLI initialization had errors! !!!"
+			"\n!!!                                          !!!"
+			"\n!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+			"\n");
+	}
 
 	// INFW: Temporary script path for hot swap testing.
 	//

--- a/goodput/src/goodput_cli.c
+++ b/goodput/src/goodput_cli.c
@@ -4655,76 +4655,9 @@ struct cli_cmd *goodput_cmds[] = {
     &UMDStart,
     &UMDStop,
     &UMDClose,
-    &IBAlloc,
-    &IBDealloc,
-    &Dump,
-    &Fill,
-    &OBDIO,
-    &OBDIOTxLat,
-    &OBDIORxLat,
-    &dmaTxLat,
-    &dmaRxLat,
-    &dma,
-    &dmaNum,
-    &dmaRxGoodput,
-    &msgTx,
-    &msgRx,
-    &msgTxLat,
-    &msgRxLat,
-    &msgTxOh,
-    &msgRxOh,
-    &Goodput,
-    &Lat,
-    &Status,
-    &Thread,
-    &Kill,
-    &Halt,
-    &Move,
-    &Wait,
-    &Sleep,
-    &CPUOccSet,
-    &CPUOccDisplay,
-    &Mpdevs,
-    &Multicast,
-    &UTime,
-    &RegScrub,
-    &LRead,
-    &LWrite,
-    &RRead,
-    &RWrite,
-    &QueryDma,
-    &SevenTest,
-    &SevenHotSwap,
-    &SevenStatus,
-    &SevenMagic,
-    &SevenMECS,
-    &CPSStatus,
-    &CPSCounters,
-    &SevenClearTsi721,
-    &SevenResetTsi721,
-    &SevenResetLink,
-    &SevenLinkReq,
-    &SevenAckidSync,
-    &SevenDisablePort,
-    &CPSPortWrite,
-    &TsiPortWrite,
-    &CPSVerification,
-    &CPSEvent,
-    &CPSReset,
-    &FileRegs,
-    &CPSHotSwap,
-    &MaintTraffic,
-    &Tsi721W,
-    &Tsi721Z,
-    &UMDOpen,
-    &UMDConfig,
-    &UMDStart,
-    &UMDStop,
-    &UMDClose,
-    &UMDDmaNum
 };
 
-void bind_goodput_cmds(void)
+int bind_goodput_cmds(void)
 {
     dump_idx = 0;
     dump_base_offset = 0;
@@ -4748,7 +4681,8 @@ void bind_goodput_cmds(void)
     sem_init(&tsi721_mutex, 0, 0);
     sem_post(&tsi721_mutex);
 
-    add_commands_to_cmd_db(sizeof(goodput_cmds) / sizeof(goodput_cmds[0]),
+    return add_commands_to_cmd_db(
+            sizeof(goodput_cmds) / sizeof(goodput_cmds[0]),
             goodput_cmds);
 }
 


### PR DESCRIPTION
Alter CLI initialization procedures to report errors when initializing.
Add error reporting to flash screen when CLI initializes.

Remove duplicate commands from being bound in.
Adjust maximum number of commands back to previous figure of 100.