### PR TITLE
Idt/cwarring umd goodput worker threads

### DIFF
--- a/goodput/common/tsi721_umd/src/tsi721_umd.c
+++ b/goodput/common/tsi721_umd/src/tsi721_umd.c
@@ -265,8 +265,6 @@ int32_t tsi721_umd_send(struct tsi721_umd* h, void* phys_addr, uint32_t num_byte
 	int8_t chan = -1;
 	tsi721_dma_desc descriptor;
 
-    printf("tsi721_umd_send phys %p sz %x rio %lx dest %d\n",phys_addr,num_bytes,rio_addr,dest_id);
-
 	// Form descriptor in local mem
 	tsi721_umd_create_dma_descriptor(
 		&descriptor, // dest pointer

--- a/goodput/common/tsi721_umd/src/tsi721_umd.c
+++ b/goodput/common/tsi721_umd/src/tsi721_umd.c
@@ -265,6 +265,8 @@ int32_t tsi721_umd_send(struct tsi721_umd* h, void* phys_addr, uint32_t num_byte
 	int8_t chan = -1;
 	tsi721_dma_desc descriptor;
 
+    printf("tsi721_umd_send phys %p sz %x rio %lx dest %d\n",phys_addr,num_bytes,rio_addr,dest_id);
+
 	// Form descriptor in local mem
 	tsi721_umd_create_dma_descriptor(
 		&descriptor, // dest pointer

--- a/goodput/common/tsi721_umd/src/tsi721_umd.c
+++ b/goodput/common/tsi721_umd/src/tsi721_umd.c
@@ -106,6 +106,7 @@ int32_t tsi721_umd_open(struct tsi721_umd* h, uint32_t mport_id)
 	}
 
 	h->state = TSI721_UMD_STATE_UNCONFIGURED;
+	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }
@@ -227,6 +228,8 @@ int32_t tsi721_umd_queue_config_multi(struct tsi721_umd* h, uint8_t channel_mask
 		return -1;
 
 	h->state = TSI721_UMD_STATE_CONFIGURED;
+	printf("engine %p state now %d\n",h,h->state);
+
 	return 0;
 }
 
@@ -251,6 +254,7 @@ int32_t tsi721_umd_start(struct tsi721_umd* h)
 	}
 
 	h->state = TSI721_UMD_STATE_READY;
+	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }
@@ -369,6 +373,7 @@ int32_t tsi721_umd_stop(struct tsi721_umd* h)
 	}
 
 	h->state = TSI721_UMD_STATE_CONFIGURED;
+	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }
@@ -385,6 +390,7 @@ int32_t tsi721_umd_close(struct tsi721_umd* h)
 	close(h->dev_fd);
 
 	h->state = TSI721_UMD_STATE_UNALLOCATED;
+	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }

--- a/goodput/common/tsi721_umd/src/tsi721_umd.c
+++ b/goodput/common/tsi721_umd/src/tsi721_umd.c
@@ -106,7 +106,6 @@ int32_t tsi721_umd_open(struct tsi721_umd* h, uint32_t mport_id)
 	}
 
 	h->state = TSI721_UMD_STATE_UNCONFIGURED;
-	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }
@@ -228,7 +227,6 @@ int32_t tsi721_umd_queue_config_multi(struct tsi721_umd* h, uint8_t channel_mask
 		return -1;
 
 	h->state = TSI721_UMD_STATE_CONFIGURED;
-	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }
@@ -254,7 +252,6 @@ int32_t tsi721_umd_start(struct tsi721_umd* h)
 	}
 
 	h->state = TSI721_UMD_STATE_READY;
-	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }
@@ -373,7 +370,6 @@ int32_t tsi721_umd_stop(struct tsi721_umd* h)
 	}
 
 	h->state = TSI721_UMD_STATE_CONFIGURED;
-	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }
@@ -390,7 +386,6 @@ int32_t tsi721_umd_close(struct tsi721_umd* h)
 	close(h->dev_fd);
 
 	h->state = TSI721_UMD_STATE_UNALLOCATED;
-	printf("engine %p state now %d\n",h,h->state);
 
 	return 0;
 }

--- a/goodput/inc/goodput_cli.h
+++ b/goodput/inc/goodput_cli.h
@@ -51,6 +51,7 @@ extern "C" {
  */
 
 int bind_goodput_cmds(void);
+extern int gp_parse_worker_index_check_thread(struct cli_env *env, char *tok, uint16_t *idx, int want_halted);
 
 #ifdef __cplusplus
 }

--- a/goodput/inc/goodput_umd_cli.h
+++ b/goodput/inc/goodput_umd_cli.h
@@ -44,9 +44,6 @@ extern struct cli_cmd UMDStart;
 extern struct cli_cmd UMDStop;
 extern struct cli_cmd UMDClose;
 
-int umd_dma_tx_num_cmd(struct worker *info, int index);
-    
-
 #ifdef __cplusplus
 }
 #endif

--- a/goodput/inc/goodput_umd_cli.h
+++ b/goodput/inc/goodput_umd_cli.h
@@ -43,7 +43,7 @@ extern struct cli_cmd UMDConfig;
 extern struct cli_cmd UMDStart;
 extern struct cli_cmd UMDStop;
 extern struct cli_cmd UMDClose;
-    
+extern struct cli_cmd UMDDma;    
 
 #ifdef __cplusplus
 }

--- a/goodput/inc/goodput_umd_cli.h
+++ b/goodput/inc/goodput_umd_cli.h
@@ -43,6 +43,8 @@ extern struct cli_cmd UMDConfig;
 extern struct cli_cmd UMDStart;
 extern struct cli_cmd UMDStop;
 extern struct cli_cmd UMDClose;
+
+int umd_dma_tx_num_cmd(struct worker *info, int index);
     
 
 #ifdef __cplusplus

--- a/goodput/inc/umd_worker.h
+++ b/goodput/inc/umd_worker.h
@@ -104,7 +104,7 @@ extern int umd_stop(struct UMDEngineInfo *info);
 
 extern int umd_close(struct UMDEngineInfo *info);
 
-extern int umd_dma_num_cmd(struct UMDEngineInfo *info, int idx);
+extern int umd_dma_num_cmd(struct worker *worker_info);
 
 #ifdef __cplusplus
 }

--- a/goodput/inc/umd_worker.h
+++ b/goodput/inc/umd_worker.h
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef __UMD_WORKER_H__
 #define __UMD_WORKER_H__
 
+#include "worker.h"
 #include "tsi721_umd.h"
 
 #ifdef __cplusplus
@@ -109,7 +110,7 @@ extern int umd_close(struct UMDEngineInfo *info);
 
 extern int umd_dma_num_cmd(struct UMDEngineInfo *info, int index);
 
-extern int umd_goodput(struct UMDEngineInfo *info, int index);
+extern void umd_goodput(struct worker *info);
 
 #ifdef __cplusplus
 }

--- a/goodput/inc/umd_worker.h
+++ b/goodput/inc/umd_worker.h
@@ -104,7 +104,7 @@ extern int umd_stop(struct UMDEngineInfo *info);
 
 extern int umd_close(struct UMDEngineInfo *info);
 
-extern int umd_dma_num_cmd(struct worker *worker_info);
+extern int umd_dma_num_cmd(struct worker *worker_info, uint32_t iter);
 
 #ifdef __cplusplus
 }

--- a/goodput/inc/umd_worker.h
+++ b/goodput/inc/umd_worker.h
@@ -106,6 +106,7 @@ extern int umd_close(struct UMDEngineInfo *info);
 
 extern int umd_dma_num_cmd(struct UMDEngineInfo *info, int index);
 
+extern int umd_dma_cmd(struct UMDEngineInfo *info, int index);
 
 #ifdef __cplusplus
 }

--- a/goodput/inc/umd_worker.h
+++ b/goodput/inc/umd_worker.h
@@ -61,9 +61,12 @@ struct DmaTransfer
     bool wr;
     int  dest_id;
     uint64_t rio_addr; /* Target RapidIO address for direct IO and DMA */
-    uint64_t buf_size; /* Number of bytes to access for direct IO and DMA */
+    uint64_t buf_size; /* Total mumber of bytes to access for direct IO and DMA */
+    uint64_t acc_size; /* Access size of one DMA iteratioin*/
     uint32_t num_trans; /* Number of loops for data transfer. 0 indicates infinite number of loops*/
     uint64_t user_data; /*User predinfed data*/
+    struct timespec st_time; /* Start of the run, for throughput */
+    struct timespec end_time; /* End of the run, for throughput*/
 
     int ib_valid;
     uint64_t ib_handle; /* Inbound window RapidIO handle */
@@ -106,7 +109,7 @@ extern int umd_close(struct UMDEngineInfo *info);
 
 extern int umd_dma_num_cmd(struct UMDEngineInfo *info, int index);
 
-extern int umd_dma_cmd(struct UMDEngineInfo *info, int index);
+extern int umd_goodput(struct UMDEngineInfo *info, int index);
 
 #ifdef __cplusplus
 }

--- a/goodput/inc/umd_worker.h
+++ b/goodput/inc/umd_worker.h
@@ -104,8 +104,7 @@ extern int umd_stop(struct UMDEngineInfo *info);
 
 extern int umd_close(struct UMDEngineInfo *info);
 
-extern int umd_dma_num_cmd(struct UMDEngineInfo *info, int index);
-
+extern int umd_dma_num_cmd(struct UMDEngineInfo *info, int idx);
 
 #ifdef __cplusplus
 }

--- a/goodput/inc/worker.h
+++ b/goodput/inc/worker.h
@@ -63,6 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "libtime_utils.h"
 #include "RapidIO_Device_Access_Routines_API.h"
 #include "liblist.h"
+#include "tsi721_umd.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -230,6 +231,9 @@ struct worker {
 	uint32_t seven_test_err_resp_time;
 	uint32_t seven_test_resp_to_time;
 	float seven_test_delay;
+
+	struct UMDEngineInfo *umd_engine;
+    uint64_t user_data;
 };
 
 /**

--- a/goodput/inc/worker.h
+++ b/goodput/inc/worker.h
@@ -330,6 +330,7 @@ uint32_t tsi721_link_req(uint32_t *response);
 extern int alloc_dma_tx_buffer(struct worker *info);
 extern void dealloc_dma_tx_buffer(struct worker *info);
 extern void zero_stats(struct worker *info);
+extern void start_iter_stats(struct worker *info);
 extern void finish_iter_stats(struct worker *info);
 
 #ifdef __cplusplus

--- a/goodput/inc/worker.h
+++ b/goodput/inc/worker.h
@@ -63,6 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "libtime_utils.h"
 #include "RapidIO_Device_Access_Routines_API.h"
 #include "liblist.h"
+#include "tsi721_umd.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -108,6 +109,7 @@ enum req_type {
 	cps_test_switch_lock,
 	maint_traffic,
 	umd_dma_num,
+	umd_dma_thru,
 	last_action
 };
 
@@ -230,6 +232,9 @@ struct worker {
 	uint32_t seven_test_err_resp_time;
 	uint32_t seven_test_resp_to_time;
 	float seven_test_delay;
+
+	struct UMDEngineInfo *umd_engine;
+	uint64_t user_data;
 };
 
 /**
@@ -321,6 +326,11 @@ uint32_t disable_switch_port(DAR_DEV_INFO_t *dev_h,
 extern sem_t tsi721_mutex;
 
 uint32_t tsi721_link_req(uint32_t *response);
+
+extern int alloc_dma_tx_buffer(struct worker *info);
+extern void dealloc_dma_tx_buffer(struct worker *info);
+extern void zero_stats(struct worker *info);
+extern void finish_iter_stats(struct worker *info);
 
 #ifdef __cplusplus
 }

--- a/goodput/scripts/umd/thrumulti.txt
+++ b/goodput/scripts/umd/thrumulti.txt
@@ -1,0 +1,42 @@
+// Start the UMD, then do the throughput test
+
+Ustop
+Uclose
+
+Uopen
+Uconfig 0x20
+Ustart
+k 3
+k 4
+k 5
+k 6
+k 7
+k 8
+
+w 3 D
+w 4 D
+w 5 D
+w 6 D
+w 7 D
+w 8 D
+
+t 3 -1 0
+t 4 -1 0
+t 5 -1 0
+t 6 -1 0
+t 7 -1 0
+t 8 -1 0
+
+w 3 H
+w 4 H
+w 5 H
+w 6 H
+w 7 H
+w 8 H
+
+Udma 3 5 0x200000000 0x100000 0x100000
+Udma 4 5 0x200000000 0x100000 0x100000
+Udma 5 5 0x200000000 0x100000 0x100000
+Udma 6 5 0x200000000 0x100000 0x100000
+Udma 7 5 0x200000000 0x100000 0x100000
+Udma 8 5 0x200000000 0x100000 0x100000

--- a/goodput/scripts/umd/thruput.txt
+++ b/goodput/scripts/umd/thruput.txt
@@ -1,0 +1,7 @@
+// Start the UMD, then do the throughput test
+
+Uopen
+Uconfig 0x20
+Ustart
+t 3 -1 0
+Udma 3 5 0x200000000 0x100000 0x100000

--- a/goodput/src/goodput_cli.c
+++ b/goodput/src/goodput_cli.c
@@ -477,6 +477,7 @@ static int IBAllocCmd(struct cli_env *env, int argc, char **argv)
         goto exit;
     }
 
+    printf("IBallocCmd: RIO %lx sz %lx handle %p\n",ib_rio_addr,ib_size,(void*)ib_phys_addr);
     wkr[idx].action = alloc_ibwin;
     wkr[idx].ib_byte_cnt = ib_size;
     wkr[idx].ib_rio_addr = ib_rio_addr;

--- a/goodput/src/goodput_cli.c
+++ b/goodput/src/goodput_cli.c
@@ -4655,6 +4655,7 @@ struct cli_cmd *goodput_cmds[] = {
     &UMDStart,
     &UMDStop,
     &UMDClose,
+    &UMDDma,
 };
 
 int bind_goodput_cmds(void)

--- a/goodput/src/goodput_cli.c
+++ b/goodput/src/goodput_cli.c
@@ -98,6 +98,8 @@ char *req_type_str[(int)last_action+1] = {
     (char *)"Pol4PW",
     (char *)"SwLock",
     (char *)"Maint ",
+    (char *)"UDnum ",
+    (char *)"UDthru",
     (char *)"LAST"
 };
 
@@ -115,7 +117,7 @@ static int gp_parse_worker_index(struct cli_env *env, char *tok, uint16_t *idx)
 
 // Parse the token ensuring it is within the range for a worker index and
 // check the status of the worker thread.
-static int gp_parse_worker_index_check_thread(struct cli_env *env, char *tok,
+int gp_parse_worker_index_check_thread(struct cli_env *env, char *tok,
         uint16_t *idx, int want_halted)
 {
     if (gp_parse_worker_index(env, tok, idx)) {

--- a/goodput/src/goodput_umd_cli.c
+++ b/goodput/src/goodput_umd_cli.c
@@ -371,12 +371,10 @@ int umdConfigCmd(struct cli_env *env, int argc, char **argv)
     }
 
     engine_p->chan_mask = (uint8_t)chan_mask;
-    if(!umd_config(engine_p))
-    {
-        ret = 0;
-    }
+    ret = umd_config(engine_p);
+    LOGMSG(env, "\nOpen returned %d\n", ret);
 
-    return ret;
+    return 0;
 }
 
 struct cli_cmd UMDConfig =
@@ -396,16 +394,14 @@ struct cli_cmd UMDConfig =
 
 int umdStartCmd(struct cli_env *env, int UNUSED(argc), char **UNUSED(argv))
 {
-    int ret = -1;
+    int ret;
     struct UMDEngineInfo *engine_p = &umd_engine;
     engine_p->env = env;
 
-    if(!umd_start(engine_p))
-    {
-        ret = 0;
-    }
+    ret = umd_start(engine_p);
+    LOGMSG(env, "\nStart returned %d\n", ret);
 
-    return ret;
+    return 0;
 }
 
 struct cli_cmd UMDStart =
@@ -423,16 +419,14 @@ struct cli_cmd UMDStart =
 
 int umdStopCmd(struct cli_env *env, int UNUSED(argc), char **UNUSED(argv))
 {
-    int ret = -1;
+    int ret;
     struct UMDEngineInfo *engine_p = &umd_engine;
     engine_p->env = env;
 
-    if(!umd_stop(engine_p))
-    {
-        ret = 0;
-    }
+    ret = umd_stop(engine_p);
+    LOGMSG(env, "\nStop returned %d\n", ret);
 
-    return ret;
+    return 0;
 
 }
 
@@ -452,16 +446,14 @@ struct cli_cmd UMDStop =
 
 int umdCloseCmd(struct cli_env *env, int UNUSED(argc), char **UNUSED(argv))
 {
-    int ret = -1;
+    int ret;
     struct UMDEngineInfo *engine_p = &umd_engine;
     engine_p->env = env;
 
-    if(!umd_close(engine_p))
-    {
-        ret = 0;
-    }
+    ret = umd_close(engine_p);
+    LOGMSG(env, "\nClose returned %d\n", ret);
 
-    return ret;
+    return 0;
 
 }
 

--- a/goodput/src/goodput_umd_cli.c
+++ b/goodput/src/goodput_umd_cli.c
@@ -162,6 +162,7 @@ static int UMDdmaCmd(struct cli_env *env, int UNUSED(argc), char **argv)
         dma_trans_p->dest_id = did_val;
         dma_trans_p->rio_addr = rio_addr;
         dma_trans_p->buf_size = buf_sz;
+        dma_trans_p->acc_size = acc_sz;
         ret = umd_goodput(engine_p, idx);
         dma_trans_p->is_in_use = false;
     }

--- a/goodput/src/goodput_umd_cli.c
+++ b/goodput/src/goodput_umd_cli.c
@@ -251,20 +251,15 @@ int umdDmaNumCmd(struct cli_env *env, int argc, char **argv)
     wkr[idx].byte_cnt = buf_sz;
     wkr[idx].acc_size = buf_sz;
     wkr[idx].wr = (int)wr;
-    //wkr[idx].use_kbuf = (int)kbuf;
     wkr[idx].use_kbuf = 1;
-    //wkr[idx].dma_trans_type = convert_int_to_riomp_dma_directio_type(trans);
     wkr[idx].dma_trans_type = RIO_EXCHANGE_NWRITE;
     wkr[idx].dma_sync_type = RIO_TRANSFER_ASYNC;
     wkr[idx].rdma_buff_size = ib_size;
     wkr[idx].num_trans = (int)num_trans;
     wkr[idx].user_data = user_data;
-    LOGMSG(env, "Wr %x kbuf %x trans %x sync %x num %x\n",
-        wkr[idx].wr, wkr[idx].use_kbuf,
-        wkr[idx].dma_trans_type, wkr[idx].dma_sync_type,
-        wkr[idx].num_trans);
 
-    wkr[idx].stop_req = 1; // TBD - add continuous test
+    ret = 0;
+
     sem_post(&wkr[idx].run);
 
 exit:

--- a/goodput/src/goodput_umd_cli.c
+++ b/goodput/src/goodput_umd_cli.c
@@ -254,9 +254,11 @@ int umdDmaNumCmd(struct cli_env *env, int argc, char **argv)
     wkr[idx].use_kbuf = 1;
     wkr[idx].dma_trans_type = RIO_EXCHANGE_NWRITE;
     wkr[idx].dma_sync_type = RIO_TRANSFER_ASYNC;
-    wkr[idx].rdma_buff_size = ib_size;
+    wkr[idx].rdma_buff_size = buf_sz;
     wkr[idx].num_trans = (int)num_trans;
     wkr[idx].user_data = user_data;
+    LOGMSG(env, "Wr %x rio 0x%lx num_trans %d sz 0x%lx\n",
+        wr, rio_addr, num_trans, buf_sz);
 
     ret = 0;
 

--- a/goodput/src/goodput_umd_cli.c
+++ b/goodput/src/goodput_umd_cli.c
@@ -105,15 +105,13 @@ static int gp_parse_did(struct cli_env *env, char *tok, did_val_t *did_val)
     return 0;
 }
 
-static int UMDdmaCmd(struct cli_env *env, int argc, char **argv)
+static int UMDdmaCmd(struct cli_env *env, int UNUSED(argc), char **argv)
 {
     int idx;
-    uint64_t ib_size;
-    uint64_t ib_rio_addr = RIO_MAP_ANY_ADDR;
     did_val_t did_val;
     uint64_t rio_addr;
     uint64_t buf_sz;
-    uint64_t user_data = DMA_USER_DATA_PATTERN;
+    uint64_t acc_sz;
     struct UMDEngineInfo *engine_p = &umd_engine;
     struct DmaTransfer *dma_trans_p;
     int ret = -1;
@@ -128,25 +126,6 @@ static int UMDdmaCmd(struct cli_env *env, int argc, char **argv)
     }
     dma_trans_p = &(engine_p->dma_trans[idx]);
 
-
-    if (gp_parse_ull_pw2(env, argv[n++], "<ib_size>", &ib_size, FOUR_KB, 4 * SIXTEEN_MB))
-    {
-        goto exit;
-    }
-
-    if(tok_parse_ulonglong(argv[n++], &ib_rio_addr, 1, UINT64_MAX, 0))
-    {
-        LOGMSG(env, "\n");
-        LOGMSG(env, TOK_ERR_ULONGLONG_HEX_MSG_FMT, "<ib_rio_addr>",
-                (uint64_t )1, (uint64_t)UINT64_MAX);
-        goto exit;
-    }
-
-    if ((ib_rio_addr != RIO_MAP_ANY_ADDR) && ((ib_size-1) & ib_rio_addr))
-    {
-        LOGMSG(env, "\n<addr> not aligned with <size>\n");
-        goto exit;
-    }
 
     if (gp_parse_did(env, argv[n++], &did_val))
     {
@@ -166,29 +145,24 @@ static int UMDdmaCmd(struct cli_env *env, int argc, char **argv)
         goto exit;
     }
 
-    if( argc > 6 && tok_parse_ull(argv[n], &user_data,0))
+    if (gp_parse_ull_pw2(env, argv[n++], "<acc_size>", &acc_sz, FOUR_KB, 4 * SIXTEEN_MB))
     {
-        LOGMSG(env, "\n");
-        LOGMSG(env, TOK_ERR_ULL_HEX_MSG_FMT, "<user_data>");
-        user_data = DMA_USER_DATA_PATTERN;
+        goto exit;
     }
-    else
+
+    if(acc_sz > buf_sz /2)
     {
-        LOGMSG(env, "User data 0x%lx\n",user_data);
+        acc_sz = buf_sz;
     }
 
     if (engine_p->stat == ENGINE_READY && !dma_trans_p->is_in_use)
     {
         //Will a mutex to lock this section if there is no plan to use woker thread infrastructure
         dma_trans_p->is_in_use = true;
-        dma_trans_p->ib_byte_cnt = ib_size;
-        dma_trans_p->ib_rio_addr = ib_rio_addr;
         dma_trans_p->dest_id = did_val;
         dma_trans_p->rio_addr = rio_addr;
         dma_trans_p->buf_size = buf_sz;
-        dma_trans_p->user_data = user_data;
-        dma_trans_p->ib_handle = RIO_MAP_ANY_ADDR;
-        ret = umd_dma_num_cmd(engine_p, idx);
+        ret = umd_goodput(engine_p, idx);
         dma_trans_p->is_in_use = false;
     }
     else
@@ -204,18 +178,15 @@ exit:
 
 struct cli_cmd UMDDma = {
     "Udma",
-    2,
-    6,
-    "Measure goodput of UMD DMA reads/writes",
-    "Udma <idx> <ib_size> <ib_rio_addr> <did> <rio_addr> <buf_sz> <data>\n"
+    3,
+    5,
+    "Measure goodput of UMD DMA writes",
+    "Udma <idx> <did> <rio_addr> <buf_sz> <acc_size>\n"
         "<idx>      User DMA test thread index: 0 to 7\n"
-        "<ib_size>  inbound window size. Must be a power of two from 0x1000 to 0x01000000\n"
-        "<ib_rio_addr> is the RapidIO address fo the inbound window\n"
-        "       NOTE: <addr> must be aligned to <size>\n"
         "<did>      target device ID\n"
         "<rio_addr> is target RapidIO memory address to access\n"
-        "<buf_sz>   target buffer size, must be a power of two from 0x1000 to 0x01000000\n"
-        "<data>     RND, or constant data value, written every 8 bytes",
+        "<buf_size> is target buffer size. Must be a power of two from 0x1000 to 0x01000000\n"
+        "<acc_size> is access size of one DMA iteration. Must be a power of two from 0x1000 to 0x01000000\n", 
     UMDdmaCmd,
     ATTR_NONE
 };

--- a/goodput/src/goodput_umd_cli.c
+++ b/goodput/src/goodput_umd_cli.c
@@ -72,6 +72,9 @@ extern "C" {
 
 struct UMDEngineInfo umd_engine;
 
+int umdOpenCmd(struct cli_env *env, int argc, char **argv);
+int umdConfigCmd(struct cli_env *env, int argc, char **argv);
+int umdStartCmd(struct cli_env *env, int argc, char **argv);
 
 // Parse the token ensuring it is within the provided range. Further ensure it
 // is a power of 2
@@ -229,6 +232,16 @@ int umdDmaNumCmd(struct cli_env *env, int argc, char **argv)
     else
     {
         LOGMSG(env, "User data 0x%lx\n",user_data);
+    }
+
+    // For convenience, if the engine is unallocated then open and allocate it now
+    // Assume mport 0
+    if (umd_engine.stat == ENGINE_UNALLOCATED)
+    {
+        printf("UMD worker started without engine ready. Opening with default mport and channels\n");
+        umdOpenCmd(env, 0, NULL);
+        umdConfigCmd(env, 0, NULL);
+        umdStartCmd(env, 0, NULL);
     }
 
     wkr[idx].action = dma_tx_num;

--- a/goodput/src/goodput_umd_cli.c
+++ b/goodput/src/goodput_umd_cli.c
@@ -236,8 +236,7 @@ int umdDmaNumCmd(struct cli_env *env, int argc, char **argv)
     wkr[idx].did_val = did_val;
     wkr[idx].rio_addr = rio_addr;
     wkr[idx].byte_cnt = buf_sz;
-    //wkr[idx].acc_size = acc_sz;
-    wkr[idx].acc_size = 0;
+    wkr[idx].acc_size = buf_sz;
     wkr[idx].wr = (int)wr;
     //wkr[idx].use_kbuf = (int)kbuf;
     wkr[idx].use_kbuf = 1;
@@ -252,44 +251,12 @@ int umdDmaNumCmd(struct cli_env *env, int argc, char **argv)
         wkr[idx].dma_trans_type, wkr[idx].dma_sync_type,
         wkr[idx].num_trans);
 
-    wkr[idx].stop_req = 0;
+    wkr[idx].stop_req = 1; // TBD - add continuous test
     sem_post(&wkr[idx].run);
 
 exit:
     return ret;
 }
-
-int umd_dma_tx_num_cmd(struct worker *info, int idx)
-{
-    UMDEngineInfo* engine_p = info->umd_engine;
-    DmaTransfer *dma_trans_p = &engine_p->dma_trans[idx];
-    dma_trans_p->ib_byte_cnt = info->byte_cnt;
-    dma_trans_p->ib_rio_addr = info->rio_addr;
-    dma_trans_p->dest_id = info->did_val;
-    dma_trans_p->rio_addr = info->rio_addr;
-    dma_trans_p->buf_size = info->rdma_buff_size;
-    dma_trans_p->num_trans = info->num_trans;
-    dma_trans_p->wr = info->wr;
-    dma_trans_p->user_data = info->user_data;
-    dma_trans_p->ib_handle = RIO_MAP_ANY_ADDR;
-
-
-    if (engine_p->stat == ENGINE_READY)
-    {
-        printf("Starting umd_dma_num_cmd\n");
-        umd_dma_num_cmd(engine_p, idx);
-        printf("Ending umd_dma_num_cmd\n");
-    }
-    else
-    {
-        printf("FAILED: User thread state %d . Engine state %d\n",dma_trans_p->is_in_use, engine_p->stat);
-        return -1;
-    }
-
-    return 0;
-}
-
-
 
 struct cli_cmd UMDDmaNum =
 {

--- a/goodput/src/goodput_umd_cli.c
+++ b/goodput/src/goodput_umd_cli.c
@@ -204,8 +204,8 @@ exit:
 
 struct cli_cmd UMDDma = {
     "Udma",
-    3,
-    9,
+    2,
+    6,
     "Measure goodput of UMD DMA reads/writes",
     "Udma <idx> <ib_size> <ib_rio_addr> <did> <rio_addr> <buf_sz> <data>\n"
         "<idx>      User DMA test thread index: 0 to 7\n"

--- a/goodput/src/umd_worker.c
+++ b/goodput/src/umd_worker.c
@@ -777,19 +777,19 @@ exit:
         uint64_t byte_cnt;
     
         LOGMSG(info->env, "INFO: Throughput completed. %u loops of UDM DMA send!!!\n", loops);
-        LOGMSG(info->env, "INFO: Total tranfer size 0x%lx\n", byte_cnt = loops * dma_trans_p->acc_size );
-        LOGMSG(info->env, "INFO: Each DMA access size 0x%lx.\n", dma_trans_p->acc_size );
-        LOGMSG(info->env, "INFO: start time %lu s:%lu ns\n", dma_trans_p->st_time.tv_sec, dma_trans_p->st_time.tv_nsec);
-        LOGMSG(info->env, "INFO: end time %lu s:%lu ns\n",dma_trans_p->end_time.tv_sec, dma_trans_p->end_time.tv_nsec);
+        LOGMSG(info->env, "INFO: Total tranfer size: 0x%lx bytes\n", byte_cnt = loops * dma_trans_p->acc_size );
+        LOGMSG(info->env, "INFO: Each DMA access size: 0x%lx bytes\n", dma_trans_p->acc_size );
+        LOGMSG(info->env, "INFO: Start time sec:%lu ns:%lu\n", dma_trans_p->st_time.tv_sec, dma_trans_p->st_time.tv_nsec);
+        LOGMSG(info->env, "INFO: End time sec:%lu ns:%lu\n",dma_trans_p->end_time.tv_sec, dma_trans_p->end_time.tv_nsec);
 
-        elapsed_time = time_difference(dma_trans_p->st_time, dma_trans_p->st_time);
+        elapsed_time = time_difference(dma_trans_p->st_time, dma_trans_p->end_time);
         nsec = elapsed_time.tv_nsec + (elapsed_time.tv_sec * 1000000000);
 
         //1000 or 1024???
         MBps = (float)(byte_cnt / (1024*1024)) / ((float)nsec / 1000000000.0);
         Gbps = (MBps * 1024.0 * 1024.0 * 8.0) / 1000000000.0;
-        LOGMSG(info->env, "INFO: duration %lu ns\n", nsec);
-        LOGMSG(info->env, "INFO: Goodput %4.3f MBps, %2.3f Gbp\n", MBps, Gbps);
+        LOGMSG(info->env, "INFO: duration ns:%lu\n", nsec);
+        LOGMSG(info->env, "INFO: Goodput %4.4fMBps, %2.4fGbp\n", MBps, Gbps);
     }   
     return ret;
 }

--- a/goodput/src/umd_worker.c
+++ b/goodput/src/umd_worker.c
@@ -339,7 +339,7 @@ int umd_dma_num_cmd(struct worker *worker_info)
     int index = worker_info->idx;
     DmaTransfer* dma_trans_p = &info->dma_trans[index];
 
-    printf("umd_dma_num_cmd: worker ib_byte_cnt %lx byte_cnt %lx\n",worker_info->ib_byte_cnt,worker_info->byte_cnt);
+    printf("umd_dma_num_cmd: wr %d worker ib_byte_cnt %lx byte_cnt %lx\n",worker_info->wr,worker_info->ib_byte_cnt,worker_info->byte_cnt);
     dma_trans_p->ib_byte_cnt = worker_info->ib_byte_cnt;
     dma_trans_p->ib_rio_addr = worker_info->ib_rio_addr;
     dma_trans_p->dest_id     = worker_info->did_val;
@@ -359,17 +359,14 @@ int umd_dma_num_cmd(struct worker *worker_info)
         goto exit;
     }
 
-    printf("Inbound window ok\n");
     memset(dma_trans_p->ib_ptr, 0x0, dma_trans_p->ib_byte_cnt);
 
-    printf("tx_ptr %p, allocate buffer\n",dma_trans_p->tx_ptr);
     if(!dma_trans_p->tx_ptr && umd_allo_tx_buf(info,index) != 0)
     {
         ret  = -1;
         goto exit;
     }
 
-    printf("tx_ptr %p\n",dma_trans_p->tx_ptr);
     if (!dma_trans_p->rio_addr || !dma_trans_p->buf_size)
     {
         LOGMSG(info->env, "FAILED: rio_addr, buf_size is 0!\n");
@@ -486,6 +483,7 @@ int umd_dma_num_cmd(struct worker *worker_info)
     {
         status = (data_status*)dma_trans_p->tx_ptr;
         prefix = (data_prefix*)dma_trans_p->ib_ptr;
+        printf("UMD worker: receiver, status %p prefix %p\n",dma_trans_p->tx_ptr,dma_trans_p->ib_ptr);
 
         for(i=0; i<loops; i++)
         {

--- a/goodput/src/umd_worker.c
+++ b/goodput/src/umd_worker.c
@@ -412,7 +412,8 @@ int umd_dma_num_cmd(struct worker *worker_info, uint32_t iter)
         goto exit;
     }
 
-    memset(dma_trans_p->ib_ptr, 0x0, dma_trans_p->ib_byte_cnt);
+    if (iter == 0)
+        memset(dma_trans_p->ib_ptr, 0x0, dma_trans_p->ib_byte_cnt);
 
     if(!dma_trans_p->tx_ptr && umd_allo_tx_buf(info,index) != 0)
     {

--- a/goodput/src/umd_worker.c
+++ b/goodput/src/umd_worker.c
@@ -777,7 +777,7 @@ exit:
         uint64_t byte_cnt;
     
         LOGMSG(info->env, "INFO: Throughput completed. %u loops of UDM DMA send!!!\n", loops);
-        LOGMSG(info->env, "INFO: Total tranfer size: 0x%lx bytes\n", byte_cnt = loops * dma_trans_p->acc_size );
+        LOGMSG(info->env, "INFO: Total transfer size: 0x%lx bytes\n", byte_cnt = loops * dma_trans_p->acc_size );
         LOGMSG(info->env, "INFO: Each DMA access size: 0x%lx bytes\n", dma_trans_p->acc_size );
         LOGMSG(info->env, "INFO: Start time sec:%lu ns:%lu\n", dma_trans_p->st_time.tv_sec, dma_trans_p->st_time.tv_nsec);
         LOGMSG(info->env, "INFO: End time sec:%lu ns:%lu\n",dma_trans_p->end_time.tv_sec, dma_trans_p->end_time.tv_nsec);
@@ -789,7 +789,7 @@ exit:
         MBps = (float)(byte_cnt / (1024*1024)) / ((float)nsec / 1000000000.0);
         Gbps = (MBps * 1024.0 * 1024.0 * 8.0) / 1000000000.0;
         LOGMSG(info->env, "INFO: duration ns:%lu\n", nsec);
-        LOGMSG(info->env, "INFO: Goodput %4.4fMBps, %2.4fGbp\n", MBps, Gbps);
+        LOGMSG(info->env, "INFO: Goodput %4.4fMBps, %2.4fGbps\n", MBps, Gbps);
     }   
     return ret;
 }

--- a/goodput/src/umd_worker.c
+++ b/goodput/src/umd_worker.c
@@ -722,6 +722,42 @@ exit:
     return ret;
 }
 
+int umd_dma_cmd(struct UMDEngineInfo *info, int index)
+{
+    struct DmaTransfer *dma_trans_p = &info->dma_trans[index];
+    int32_t ret = 0;
+    uint32_t loops=0;
+
+     if(umd_allo_ibw(info, index))
+     {
+         ret = -1;
+         goto exit;
+     }
+
+     if(umd_allo_tx_buf(info,index))
+     {
+         ret  = -1;
+         goto exit;
+     }
+
+    if (!dma_trans_p->rio_addr || !dma_trans_p->buf_size)
+    {
+        LOGMSG(info->env, "FAILED: rio_addr, buf_size is 0!\n");
+        ret = -1;
+        goto exit;
+    }
+
+exit:
+    umd_free_ibw(info,index);
+    umd_free_tx_buf(info, index);
+    if( ret == 0)
+    {
+        LOGMSG(info->env,"INFO: Writer/Reader %d completed %u loops of UDM DMA test successfully!!!\n", dma_trans_p->wr, loops);
+    }
+    return ret;
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/goodput/src/umd_worker.c
+++ b/goodput/src/umd_worker.c
@@ -622,6 +622,19 @@ int umd_dma_num_cmd(struct UMDEngineInfo *info, int index)
                 prefix->pattern[7] == 0xF1)
             {
                suffix = (data_suffix*)((uint64_t)(dma_trans_p->ib_ptr) + prefix->xfer_offset + prefix->xfer_size);
+
+               while(suffix->pattern[0] == 00 &&
+                    suffix->pattern[1] == 00 &&
+                    suffix->pattern[2] == 00 &&
+                    suffix->pattern[3] == 00 &&
+                    suffix->pattern[4] == 00 &&
+                    suffix->pattern[5] == 00 &&
+                    suffix->pattern[6] == 00 &&
+                    suffix->pattern[7] == 00)
+               {
+                   sleep(0.25);
+               }
+                    
                if(suffix->pattern[0] == 0x1a &&
                     suffix->pattern[1] == 0x2b &&
                     suffix->pattern[2] == 0x3c &&

--- a/goodput/src/umd_worker.c
+++ b/goodput/src/umd_worker.c
@@ -328,7 +328,7 @@ int umd_config(struct UMDEngineInfo *info)
 
             if(!tsi721_umd_queue_config_multi(&(info->engine), info->chan_mask, (void *)info->queue_mem_h, UDM_QUEUE_SIZE))
             {
-                LOGMSG(info->env, "SUCC: UDM queue is configured. Channel mask 0x%x\n", info->chan_mask);  
+                LOGMSG(info->env, "SUCC: UMD queue is configured. Channel mask 0x%x\n", info->chan_mask);  
                 info->stat = ENGINE_CONFIGURED;
                 return 0;
             }
@@ -421,13 +421,13 @@ int umd_close(struct UMDEngineInfo *info)
 
 int umd_dma_num_cmd(struct UMDEngineInfo *info, int index)
 {
-    struct DmaTransfer *dma_trans_p = &info->dma_trans[index];
     data_status *status;
     data_prefix *prefix;
     data_suffix *suffix = NULL;
     int32_t ret = 0, rc;
     uint32_t i;
     uint32_t loops;
+    DmaTransfer* dma_trans_p = &info->dma_trans[index];
 
      if(umd_allo_ibw(info, index))
      {

--- a/goodput/src/umd_worker.c
+++ b/goodput/src/umd_worker.c
@@ -735,6 +735,7 @@ void umd_goodput(struct worker *info)
     clock_gettime(CLOCK_MONOTONIC, &info->st_time);
 
     while (!info->stop_req) {
+        start_iter_stats(info);
         for (uint64_t count = 0; (count < info->byte_cnt) && !info->stop_req;
 			 count += info->acc_size)
         {
@@ -757,6 +758,7 @@ void umd_goodput(struct worker *info)
             }
 	}
         info->perf_byte_cnt += info->byte_cnt;
+        finish_iter_stats(info);
         clock_gettime(CLOCK_MONOTONIC, &info->end_time);
     }
 

--- a/goodput/src/worker.c
+++ b/goodput/src/worker.c
@@ -904,7 +904,12 @@ void dma_tx_num_cmd(struct worker *info)
         ts_now_mark(&info->meas_ts, 5);
 
         if (info->action_mode == user_mode_action) {
-            umd_dma_num_cmd(info, trans_count);
+            dma_rc = umd_dma_num_cmd(info, trans_count);
+            if (dma_rc < 0) {
+                ERR("FAILED: dma_rc %d on trans %d!\n",
+                    dma_rc, trans_count);
+                return;
+            }
         }
         else {
             dma_rc = single_dma_access(info, 0);
@@ -926,6 +931,11 @@ void dma_tx_num_cmd(struct worker *info)
     }
 
     clock_gettime(CLOCK_MONOTONIC, &info->end_time);
+
+    if (info->action_mode == user_mode_action)
+    {
+        printf("Success for %d transfers\n",trans_count);
+    }
 
     while (!info->stop_req) {
         sleep(0);

--- a/goodput/src/worker.c
+++ b/goodput/src/worker.c
@@ -73,6 +73,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "worker.h"
 #include "pw_handling.h"
 #include "goodput.h"
+#include "umd_worker.h"
 #include "Tsi721.h"
 #include "CPS1848.h"
 #include "rio_misc.h"
@@ -1630,6 +1631,9 @@ void *worker_thread(void *parm)
         case maint_traffic:
             do_maint_traffic(info);
             break;
+	case umd_dma_thru:
+	    umd_goodput(info);
+	    break;
         case no_action:
         case last_action:
         default:

--- a/goodput/src/worker.c
+++ b/goodput/src/worker.c
@@ -904,7 +904,7 @@ void dma_tx_num_cmd(struct worker *info)
         ts_now_mark(&info->meas_ts, 5);
 
         if (info->action_mode == user_mode_action) {
-            umd_dma_num_cmd(info);
+            umd_dma_num_cmd(info, trans_count);
         }
         else {
             dma_rc = single_dma_access(info, 0);

--- a/goodput/src/worker.c
+++ b/goodput/src/worker.c
@@ -904,7 +904,7 @@ void dma_tx_num_cmd(struct worker *info)
         ts_now_mark(&info->meas_ts, 5);
 
         if (info->action_mode == user_mode_action) {
-            umd_dma_num_cmd(info->umd_engine, info->idx);
+            umd_dma_num_cmd(info);
         }
         else {
             dma_rc = single_dma_access(info, 0);

--- a/goodput/src/worker.c
+++ b/goodput/src/worker.c
@@ -82,6 +82,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RapidIO_Port_Config_API.h"
 #include "RapidIO_Routing_Table_API.h"
 
+#include "umd_worker.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -89,6 +91,8 @@ extern "C" {
 volatile int devid_status[MAX_DEVID_STATUS];
 
 sem_t tsi721_mutex;
+
+extern struct UMDEngineInfo umd_engine;
 
 void init_worker_info(struct worker *info, int first_time)
 {
@@ -160,9 +164,7 @@ void init_worker_info(struct worker *info, int first_time)
     info->dsdist = 0;
     info->dssize = 0;
 
-    //info->umd_engine_h = 0;
-    //info->umd_queue_h = 0;
-
+    info->umd_engine = NULL;
 }
 
 void msg_cleanup_con_skt(struct worker *info);
@@ -900,19 +902,26 @@ void dma_tx_num_cmd(struct worker *info)
 
     for (trans_count = 0; trans_count < info->num_trans; trans_count++) {
         ts_now_mark(&info->meas_ts, 5);
-        dma_rc = single_dma_access(info, 0);
-        if (dma_rc < 0) {
-            ERR("FAILED: dma_rc %d on trans %d!\n",
-                dma_rc, trans_count);
-            return;
+
+        if (info->action_mode == user_mode_action) {
+            umd_dma_num_cmd(info->umd_engine, info->idx);
         }
-        if (RIO_TRANSFER_ASYNC == info->dma_sync_type) {
-            dma_rc = rio_wait_async(info->mp_h, dma_rc, 0);
-            if (dma_rc) {
-                ERR("FAILED: DMA WAIT RC %d\n", dma_rc);
-                goto exit;
+        else {
+            dma_rc = single_dma_access(info, 0);
+            if (dma_rc < 0) {
+                ERR("FAILED: dma_rc %d on trans %d!\n",
+                    dma_rc, trans_count);
+                return;
+            }
+            if (RIO_TRANSFER_ASYNC == info->dma_sync_type) {
+                dma_rc = rio_wait_async(info->mp_h, dma_rc, 0);
+                if (dma_rc) {
+                    ERR("FAILED: DMA WAIT RC %d\n", dma_rc);
+                    goto exit;
+                }
             }
         }
+            
         ts_now_mark(&info->meas_ts, 555);
     }
 
@@ -1663,6 +1672,9 @@ void start_worker_thread(struct worker *info, int new_mp_h, int cpu)
     } else {
         info->mp_h = mp_h;
     }
+
+    info->umd_engine = &umd_engine;
+
     info->mp_num = mp_h_num;
     info->wkr_thr.cpu_req = cpu;
 


### PR DESCRIPTION
Goodput TSI721 UMD test changes
* Merge the dma test from idt/beijing_umd_dev and idt/barry_thru_test_dev.  Refer to "udma" command in Goodput
* Change Udnum test to use the worker thread infrastructure.  Some changes to arguments and behaviour to more closely match the Dnum command
* To start Udnum you will now need to first run the "thread" and "IBAlloc" commands, and Udnum will use the inbound window allocated to it by IBAlloc.
