### PR TITLE
Idt/cwarring umd dev fairness

### DIFF
--- a/goodput/common/tsi721_umd/src/tsi721_umd.c
+++ b/goodput/common/tsi721_umd/src/tsi721_umd.c
@@ -335,6 +335,8 @@ int32_t tsi721_umd_send(struct tsi721_umd* h, void* phys_addr, uint32_t num_byte
 	h->chan[chan].in_use = false;
 	sem_post(&h->chan_sem); // mark a dma engine is free for use
 
+    usleep(0); // avoid this thread monopolizing, if there is a waiting sender thread allow it to run
+
 	return 0;
 }
 

--- a/goodput/common/tsi721_umd/src/tsi721_umd.c
+++ b/goodput/common/tsi721_umd/src/tsi721_umd.c
@@ -335,7 +335,7 @@ int32_t tsi721_umd_send(struct tsi721_umd* h, void* phys_addr, uint32_t num_byte
 	h->chan[chan].in_use = false;
 	sem_post(&h->chan_sem); // mark a dma engine is free for use
 
-    usleep(0); // avoid this thread monopolizing, if there is a waiting sender thread allow it to run
+	sched_yield();
 
 	return 0;
 }

--- a/goodput/common/tsi721_umd/src/tsi721_umd.c
+++ b/goodput/common/tsi721_umd/src/tsi721_umd.c
@@ -305,7 +305,7 @@ int32_t tsi721_umd_send(struct tsi721_umd* h, void* phys_addr, uint32_t num_byte
 	uint32_t status = TSI721_RD32(TSI721_DMACXSTS(chan));
 	while(status & TSI721_DMACXSTS_RUN)
 	{
-		usleep(100);
+		usleep(1);
 		status = TSI721_RD32(TSI721_DMACXSTS(chan));
 	}
 	


### PR DESCRIPTION
This combination seemed to get me the best performance and fairness of the simple changes I have tried so far.

With no sleep at register polling, performance was noticeably lower when I was running a high number of threads.

I could get better fairness by using a sleep instead of sched_yield, but at significantly worse performance.  To do better on fairness I suspect we'd have to implement a queue FIFO or some other mechanism to force the oldest waiter to get priority.